### PR TITLE
CURL errors refactoring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "keboola/csvmap": "^0.2",
         "keboola/filter": "~0.1.0",
         "symfony/yaml": "~2.6.3",
-        "guzzlehttp/retry-subscriber": "^2.0",
+        "guzzlehttp/retry-subscriber": "dev-master#270393c",
         "guzzlehttp/guzzle": "^5.3",
         "monolog/monolog": "~1.15.0",
         "keboola/codebuilder": "~0.2.0"


### PR DESCRIPTION
Removed
- method `RestClient::getBackoff()` replaced with `RestClient::createBackofff()`with other implementation **(BC BREAK)**

Fixed
- backoff on curl errors (use of patched `guzzlehttp/retry-subscriber`)
- CURL errors as `UserException`

Tests
- CURL backoff tests
