### PR TITLE
Fix ScrollerInterface, return null not false

### DIFF
--- a/src/Pagination/AbstractResponseScroller.php
+++ b/src/Pagination/AbstractResponseScroller.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\Juicer\Pagination;
 
 use Keboola\Juicer\Client\RestClient;
+use Keboola\Juicer\Client\RestRequest;
 use Keboola\Juicer\Config\JobConfig;
 
 /**
@@ -15,7 +16,7 @@ abstract class AbstractResponseScroller extends AbstractScroller
     /**
      * @inheritdoc
      */
-    public function getFirstRequest(RestClient $client, JobConfig $jobConfig)
+    public function getFirstRequest(RestClient $client, JobConfig $jobConfig): ?RestRequest
     {
         return $client->createRequest($jobConfig->getConfig());
     }

--- a/src/Pagination/CursorScroller.php
+++ b/src/Pagination/CursorScroller.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\Juicer\Pagination;
 
 use Keboola\Juicer\Client\RestClient;
+use Keboola\Juicer\Client\RestRequest;
 use Keboola\Juicer\Exception\UserException;
 use Keboola\Juicer\Config\JobConfig;
 use function Keboola\Utils\getDataFromPath;
@@ -60,7 +61,7 @@ class CursorScroller extends AbstractScroller implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getFirstRequest(RestClient $client, JobConfig $jobConfig)
+    public function getFirstRequest(RestClient $client, JobConfig $jobConfig): ?RestRequest
     {
         return $client->createRequest($jobConfig->getConfig());
     }
@@ -68,11 +69,11 @@ class CursorScroller extends AbstractScroller implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
         if (empty($data)) {
             $this->reset();
-            return false;
+            return null;
         } else {
             $cursor = 0;
 

--- a/src/Pagination/Decorator/AbstractScrollerDecorator.php
+++ b/src/Pagination/Decorator/AbstractScrollerDecorator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\Juicer\Pagination\Decorator;
 
 use Keboola\Juicer\Client\RestClient;
+use Keboola\Juicer\Client\RestRequest;
 use Keboola\Juicer\Pagination\ScrollerInterface;
 use Keboola\Juicer\Config\JobConfig;
 
@@ -26,7 +27,7 @@ abstract class AbstractScrollerDecorator implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getFirstRequest(RestClient $client, JobConfig $jobConfig)
+    public function getFirstRequest(RestClient $client, JobConfig $jobConfig): ?RestRequest
     {
         return $this->scroller->getFirstRequest($client, $jobConfig);
     }
@@ -34,7 +35,7 @@ abstract class AbstractScrollerDecorator implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
         return $this->scroller->getNextRequest($client, $jobConfig, $response, $data);
     }

--- a/src/Pagination/Decorator/ForceStopScrollerDecorator.php
+++ b/src/Pagination/Decorator/ForceStopScrollerDecorator.php
@@ -61,7 +61,7 @@ class ForceStopScrollerDecorator extends AbstractScrollerDecorator
     /**
      * @inheritdoc
      */
-    public function getFirstRequest(RestClient $client, JobConfig $jobConfig)
+    public function getFirstRequest(RestClient $client, JobConfig $jobConfig): ?RestRequest
     {
         $this->startTime = time();
         $this->pageCounter = 1;
@@ -72,11 +72,11 @@ class ForceStopScrollerDecorator extends AbstractScrollerDecorator
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
         if ($this->checkLimits($response)) {
             $this->limitReached = true;
-            return false;
+            return null;
         }
 
         return $this->scroller->getNextRequest($client, $jobConfig, $response, $data);

--- a/src/Pagination/Decorator/HasMoreScrollerDecorator.php
+++ b/src/Pagination/Decorator/HasMoreScrollerDecorator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\Juicer\Pagination\Decorator;
 
 use Keboola\Juicer\Client\RestClient;
+use Keboola\Juicer\Client\RestRequest;
 use Keboola\Juicer\Pagination\ScrollerInterface;
 use Keboola\Juicer\Config\JobConfig;
 use Keboola\Juicer\Exception\UserException;
@@ -71,10 +72,10 @@ class HasMoreScrollerDecorator extends AbstractScrollerDecorator
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
         if ($this->hasMore($response) === false) {
-            return false;
+            return null;
         }
 
         return $this->scroller->getNextRequest($client, $jobConfig, $response, $data);

--- a/src/Pagination/Decorator/LimitStopScrollerDecorator.php
+++ b/src/Pagination/Decorator/LimitStopScrollerDecorator.php
@@ -46,7 +46,7 @@ class LimitStopScrollerDecorator extends AbstractScrollerDecorator
     /**
      * @inheritdoc
      */
-    public function getFirstRequest(RestClient $client, JobConfig $jobConfig)
+    public function getFirstRequest(RestClient $client, JobConfig $jobConfig): ?RestRequest
     {
         $this->currentCount = 0;
         return $this->scroller->getFirstRequest($client, $jobConfig);
@@ -55,7 +55,7 @@ class LimitStopScrollerDecorator extends AbstractScrollerDecorator
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
         $this->currentCount += count($data);
         if ($this->fieldName) {
@@ -64,7 +64,7 @@ class LimitStopScrollerDecorator extends AbstractScrollerDecorator
             $limit = $this->countLimit;
         }
         if ($this->currentCount >= $limit) {
-            return false;
+            return null;
         }
 
         return $this->scroller->getNextRequest($client, $jobConfig, $response, $data);

--- a/src/Pagination/MultipleScroller.php
+++ b/src/Pagination/MultipleScroller.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\Juicer\Pagination;
 
 use Keboola\Juicer\Client\RestClient;
+use Keboola\Juicer\Client\RestRequest;
 use Keboola\Juicer\Exception\UserException;
 use Keboola\Juicer\Config\JobConfig;
 
@@ -58,7 +59,7 @@ class MultipleScroller extends AbstractScroller implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getFirstRequest(RestClient $client, JobConfig $jobConfig)
+    public function getFirstRequest(RestClient $client, JobConfig $jobConfig): ?RestRequest
     {
         return $this->getScrollerForJob($jobConfig)->getFirstRequest($client, $jobConfig);
     }
@@ -66,7 +67,7 @@ class MultipleScroller extends AbstractScroller implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
         return $this->getScrollerForJob($jobConfig)->getNextRequest($client, $jobConfig, $response, $data);
     }

--- a/src/Pagination/NoScroller.php
+++ b/src/Pagination/NoScroller.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\Juicer\Pagination;
 
 use Keboola\Juicer\Client\RestClient;
+use Keboola\Juicer\Client\RestRequest;
 use Keboola\Juicer\Config\JobConfig;
 
 /**
@@ -15,7 +16,7 @@ class NoScroller implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getFirstRequest(RestClient $client, JobConfig $jobConfig)
+    public function getFirstRequest(RestClient $client, JobConfig $jobConfig): ?RestRequest
     {
         return $client->createRequest($jobConfig->getConfig());
     }
@@ -23,9 +24,9 @@ class NoScroller implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
-        return false;
+        return null;
     }
 
     /**

--- a/src/Pagination/OffsetScroller.php
+++ b/src/Pagination/OffsetScroller.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\Juicer\Pagination;
 
 use Keboola\Juicer\Client\RestClient;
+use Keboola\Juicer\Client\RestRequest;
 use Keboola\Juicer\Exception\UserException;
 use Keboola\Juicer\Config\JobConfig;
 
@@ -72,7 +73,7 @@ class OffsetScroller extends AbstractScroller implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getFirstRequest(RestClient $client, JobConfig $jobConfig)
+    public function getFirstRequest(RestClient $client, JobConfig $jobConfig): ?RestRequest
     {
         if ($this->offsetFromJob && !empty($jobConfig->getParams()[$this->offsetParam])) {
             $this->pointer = $jobConfig->getParams()[$this->offsetParam];
@@ -90,11 +91,11 @@ class OffsetScroller extends AbstractScroller implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
         if (count($data) < $this->getLimit($jobConfig)) {
             $this->reset();
-            return false;
+            return null;
         } else {
             $this->pointer += $this->getLimit($jobConfig);
 

--- a/src/Pagination/PageScroller.php
+++ b/src/Pagination/PageScroller.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\Juicer\Pagination;
 
 use Keboola\Juicer\Client\RestClient;
+use Keboola\Juicer\Client\RestRequest;
 use Keboola\Juicer\Config\JobConfig;
 
 /**
@@ -64,7 +65,7 @@ class PageScroller extends AbstractScroller implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getFirstRequest(RestClient $client, JobConfig $jobConfig)
+    public function getFirstRequest(RestClient $client, JobConfig $jobConfig): ?RestRequest
     {
         if ($this->firstPageParams) {
             $config = $this->getParams($jobConfig);
@@ -78,13 +79,13 @@ class PageScroller extends AbstractScroller implements ScrollerInterface
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
         if ((is_null($this->getLimit($jobConfig)) && empty($data))
             || (count($data) < $this->getLimit($jobConfig))
         ) {
             $this->reset();
-            return false;
+            return null;
         } else {
             $this->page++;
 

--- a/src/Pagination/ResponseParamScroller.php
+++ b/src/Pagination/ResponseParamScroller.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\Juicer\Pagination;
 
 use Keboola\Juicer\Client\RestClient;
+use Keboola\Juicer\Client\RestRequest;
 use Keboola\Juicer\Config\JobConfig;
 use Keboola\Juicer\Exception\UserException;
 
@@ -56,11 +57,11 @@ class ResponseParamScroller extends AbstractResponseScroller implements Scroller
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
         $nextParam = \Keboola\Utils\getDataFromPath($this->responseParam, $response, '.');
         if (empty($nextParam)) {
-            return false;
+            return null;
         } else {
             $config = $jobConfig->getConfig();
 

--- a/src/Pagination/ResponseUrlScroller.php
+++ b/src/Pagination/ResponseUrlScroller.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\Juicer\Pagination;
 
 use Keboola\Juicer\Client\RestClient;
+use Keboola\Juicer\Client\RestRequest;
 use Keboola\Juicer\Config\JobConfig;
 use GuzzleHttp\Query;
 
@@ -51,12 +52,12 @@ class ResponseUrlScroller extends AbstractResponseScroller implements ScrollerIn
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
         $nextUrl = \Keboola\Utils\getDataFromPath($this->urlParam, $response, $this->delimiter);
 
         if (empty($nextUrl)) {
-            return false;
+            return null;
         } else {
             $config = $jobConfig->getConfig();
 

--- a/src/Pagination/ScrollerInterface.php
+++ b/src/Pagination/ScrollerInterface.php
@@ -10,21 +10,12 @@ use Keboola\Juicer\Config\JobConfig;
 
 interface ScrollerInterface
 {
-    /**
-     * @param RestClient $client
-     * @param JobConfig $jobConfig
-     * @return RestRequest|false
-     */
-    public function getFirstRequest(RestClient $client, JobConfig $jobConfig);
+    public function getFirstRequest(RestClient $client, JobConfig $jobConfig): ?RestRequest;
 
     /**
-     * @param RestClient $client
-     * @param JobConfig $jobConfig
      * @param array|object $response
-     * @param array $data
-     * @return RestRequest|false
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data);
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest;
 
     /**
      * Reset the pagination pointer

--- a/src/Pagination/ZendeskResponseUrlScroller.php
+++ b/src/Pagination/ZendeskResponseUrlScroller.php
@@ -6,6 +6,7 @@ namespace Keboola\Juicer\Pagination;
 
 use GuzzleHttp\Url;
 use Keboola\Juicer\Client\RestClient;
+use Keboola\Juicer\Client\RestRequest;
 use Keboola\Juicer\Config\JobConfig;
 use GuzzleHttp\Query;
 
@@ -44,12 +45,12 @@ class ZendeskResponseUrlScroller extends AbstractResponseScroller implements Scr
     /**
      * @inheritdoc
      */
-    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, $data)
+    public function getNextRequest(RestClient $client, JobConfig $jobConfig, $response, array $data): ?RestRequest
     {
         $nextUrl = \Keboola\Utils\getDataFromPath($this->urlParam, $response, '.');
 
         if (empty($nextUrl)) {
-            return false;
+            return null;
         }
 
         // start_time validation
@@ -59,7 +60,7 @@ class ZendeskResponseUrlScroller extends AbstractResponseScroller implements Scr
         $startDateTime = $startDateTimeStr ? \DateTime::createFromFormat('U', $startDateTimeStr) : null;
 
         if ($startDateTime && $startDateTime > $now->modify(sprintf('-%d minutes', self::NEXT_PAGE_FILTER_MINUTES))) {
-            return false;
+            return null;
         }
 
         $config = $jobConfig->getConfig();

--- a/tests/phpunit/Pagination/CursorScrollerTest.php
+++ b/tests/phpunit/Pagination/CursorScrollerTest.php
@@ -40,7 +40,7 @@ class CursorScrollerTest extends TestCase
 
         $emptyResponse = [];
         $last = $scroller->getNextRequest($client, $config, $emptyResponse, $emptyResponse);
-        self::assertFalse($last);
+        self::assertNull($last);
     }
 
     public function testGetNextRequestNested(): void

--- a/tests/phpunit/Pagination/Decorator/ForceStopScrollerDecoratorTest.php
+++ b/tests/phpunit/Pagination/Decorator/ForceStopScrollerDecoratorTest.php
@@ -36,7 +36,7 @@ class ForceStopScrollerDecoratorTest extends TestCase
             self::assertInstanceOf('Keboola\Juicer\Client\RestRequest', $request);
             $i++;
         }
-        self::assertFalse($decorator->getNextRequest($client, $jobConfig, $response, $response));
+        self::assertNull($decorator->getNextRequest($client, $jobConfig, $response, $response));
         // Assert 3 pages were true
         self::assertEquals(3, $i);
     }
@@ -84,7 +84,7 @@ class ForceStopScrollerDecoratorTest extends TestCase
             $i++;
             sleep(1);
         }
-        self::assertFalse($decorator->getNextRequest($client, $jobConfig, $response, $response));
+        self::assertNull($decorator->getNextRequest($client, $jobConfig, $response, $response));
         // Assert 3 pages were true
         self::assertEquals(3, $i);
     }

--- a/tests/phpunit/Pagination/Decorator/HasMoreScrollerDecoratorTest.php
+++ b/tests/phpunit/Pagination/Decorator/HasMoreScrollerDecoratorTest.php
@@ -45,7 +45,7 @@ class HasMoreScrollerDecoratorTest extends ExtractorTestCase
             (object) ['hasMore' => false],
             array_fill(0, 10, ['k' => 'v'])
         );
-        self::assertFalse($noNext);
+        self::assertNull($noNext);
     }
 
     public function testHasMore(): void

--- a/tests/phpunit/Pagination/Decorator/LimitStopScrollerDecoratorTest.php
+++ b/tests/phpunit/Pagination/Decorator/LimitStopScrollerDecoratorTest.php
@@ -46,7 +46,7 @@ class LimitStopScrollerDecoratorTest extends ExtractorTestCase
             $response,
             $response->results->data
         );
-        self::assertFalse($noNext);
+        self::assertNull($noNext);
     }
 
     public function testLimit(): void
@@ -79,7 +79,7 @@ class LimitStopScrollerDecoratorTest extends ExtractorTestCase
             $response,
             $response->results->data
         );
-        self::assertFalse($noNext);
+        self::assertNull($noNext);
     }
 
     public function testInvalid1(): void

--- a/tests/phpunit/Pagination/MultipleScrollerTest.php
+++ b/tests/phpunit/Pagination/MultipleScrollerTest.php
@@ -73,7 +73,7 @@ class MultipleScrollerTest extends TestCase
             $noScrollerResponse,
             $noScrollerResponse->results
         );
-        self::assertFalse($nextNone);
+        self::assertNull($nextNone);
     }
 
     public function testGetNextRequestDefault(): void

--- a/tests/phpunit/Pagination/PageScrollerTest.php
+++ b/tests/phpunit/Pagination/PageScrollerTest.php
@@ -175,7 +175,7 @@ class PageScrollerTest extends TestCase
         self::assertEquals(1, $first->getParams()['page']);
         self::assertEquals(2, $second->getParams()['page']);
         self::assertEquals(3, $third->getParams()['page']);
-        self::assertFalse($last);
+        self::assertNull($last);
     }
 
     public function testSetState(): void

--- a/tests/phpunit/Pagination/ZendeskResponseUrlScrollerTest.php
+++ b/tests/phpunit/Pagination/ZendeskResponseUrlScrollerTest.php
@@ -36,7 +36,7 @@ class ZendeskResponseUrlScrollerTest extends ResponseScrollerTestCase
             $next = $scroller->getNextRequest($client, $config, $response, $response->data);
 
             if (!$i) {
-                self::assertFalse($next);
+                self::assertNull($next);
             } else {
                 if (!$next instanceof RestRequest) {
                     self::fail('ZendeskResponseUrlScroller::getNextRequest should return new RestRequest');


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-596

Changes:
- `ScrollerInterface` methods `getFirstRequest` and `getNextRequest` return `RestRequest|null` not `RestRequest|false` -> no mixing of the data types.