### PR TITLE
Fix Host header in defaults

### DIFF
--- a/src/Client/GuzzleRequestFactory.php
+++ b/src/Client/GuzzleRequestFactory.php
@@ -15,6 +15,13 @@ use function Keboola\Utils\buildUrl;
  */
 class GuzzleRequestFactory
 {
+    private ?string $defaultHostHeader;
+
+    public function __construct(?string $defaultHostHeader)
+    {
+        $this->defaultHostHeader = $defaultHostHeader;
+    }
+
     public function create(RestRequest $restRequest): RequestInterface
     {
         $body = null;
@@ -44,6 +51,22 @@ class GuzzleRequestFactory
                 ));
         }
 
+        // Set default host header
+        if ($this->defaultHostHeader && !self::isHeaderSet('Host', $headers)) {
+            $headers['Host'] = $this->defaultHostHeader;
+        }
+
         return new Request($method, $endpoint, $headers, $body);
+    }
+
+    private static function isHeaderSet(string $header, array $headers): bool
+    {
+        foreach (array_keys($headers) as $name) {
+            if (strtolower((string) $name) === strtolower($header)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Client/RestClient.php
+++ b/src/Client/RestClient.php
@@ -78,11 +78,20 @@ class RestClient
         // Create Guzzle client
         $guzzle = new Client($guzzleConfig);
 
+        // Use host from guzzle config if present (in previous versions of Guzzle, this was done automatically)
+        $defaultHostHeader = null;
+        foreach ($guzzleConfig['headers'] ?? [] as $name => $value) {
+            if (strtolower((string) $name) === 'host') {
+                $defaultHostHeader = $value;
+                break;
+            }
+        }
+
         $this->logger = $logger;
         $this->client = $guzzle;
         $this->defaultRequestOptions = $defaultOptions;
         $this->ignoreErrors = $ignoreErrors;
-        $this->guzzleRequestFactory = new GuzzleRequestFactory();
+        $this->guzzleRequestFactory = new GuzzleRequestFactory($defaultHostHeader);
     }
 
     public function getBaseUri(): UriInterface

--- a/tests/phpunit/Client/RestClientTest.php
+++ b/tests/phpunit/Client/RestClientTest.php
@@ -353,6 +353,62 @@ class RestClientTest extends ExtractorTestCase
         );
     }
 
+    public function testHostHeaderInRequest(): void
+    {
+        $body = '[
+                {"field": "data"},
+                {"field": "more"}
+        ]';
+
+        $history = new HistoryContainer();
+        $restClient = RestClientMockBuilder::create()
+            ->addResponse200($body)
+            ->setBaseUri('http://example.com')
+            ->setGuzzleConfig(['headers' => ['X-Test' => '1234']])
+            ->setHistoryContainer($history)
+            ->getRestClient();
+
+        $request = new RestRequest([
+            'endpoint' => 'ep',
+            'headers' => [
+                'Host' => 'different.com',
+            ],
+        ]);
+
+        $restClient->download($request);
+        $lastRequest = $history->last()->getRequest();
+        self::assertEquals('different.com', $lastRequest->getHeaders()['Host'][0]);
+    }
+
+    public function testHostHeaderInConfig(): void
+    {
+        $body = '[
+                {"field": "data"},
+                {"field": "more"}
+        ]';
+
+        $history = new HistoryContainer();
+        $restClient = RestClientMockBuilder::create()
+            ->addResponse200($body)
+            ->setBaseUri('http://example.com')
+            ->setGuzzleConfig([
+                'headers' => [
+                    'X-Test' => '1234',
+                    'Host' => 'different.com',
+                ],
+            ])
+            ->setHistoryContainer($history)
+            ->getRestClient();
+
+        $request = new RestRequest([
+            'endpoint' => 'ep',
+        ]);
+
+        $restClient->download($request);
+        $lastRequest = $history->last()->getRequest();
+        self::assertEquals('different.com', $lastRequest->getHeaders()['Host'][0]);
+    }
+
     protected function runAndAssertDelay(array $retryConfig, Response $errResponse, int $expectedDelaySec): void
     {
         $body = '[

--- a/tests/phpunit/Client/RestClientTest.php
+++ b/tests/phpunit/Client/RestClientTest.php
@@ -364,7 +364,12 @@ class RestClientTest extends ExtractorTestCase
         $restClient = RestClientMockBuilder::create()
             ->addResponse200($body)
             ->setBaseUri('http://example.com')
-            ->setGuzzleConfig(['headers' => ['X-Test' => '1234']])
+            ->setGuzzleConfig([
+                'headers' => [
+                    'X-Test' => '1234',
+                    'Host' => 'default.com',
+                ],
+            ])
             ->setHistoryContainer($history)
             ->getRestClient();
 


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-596

Problem:
- Guzzle v novej verzii funguje inak, co sa tyka `host` header.
- Hoci sa nastavi defaultna hodnota v konstruktore `Client`, tak sa na vyslednom requeste neprejavi.
- Guzzle vzdy nastavi `Host` header z URL, pokial nie je v ramci requestu explicitne uvedena ina hodnota.
- Problem sa vyskytuje ak je endpoint IP/adresa VPN/proxy servera, ... napr `http://123.123.123.123/abc` ... a cez header `Host` sa musi definovat, pre aky server/host za VPN je request urceny.
- Guzzle issue: https://github.com/guzzle/guzzle/issues/1678
- ZD: https://keboola.zendesk.com/agent/tickets/17006
- Slack: https://keboola.slack.com/archives/C011BERCEBG/p1618221838027100

Riesenie/zmeny:
- Hodnotu `Host` hlavicky nastavujeme explicitne v nasom kode, vid zmeny v kode a testy.