### PR TITLE
Add retry middleware name

### DIFF
--- a/src/Client/RestClient.php
+++ b/src/Client/RestClient.php
@@ -73,7 +73,7 @@ class RestClient
 
         // Create retry middleware
         $retryMiddlewareFactory = new RetryMiddlewareFactory($logger, $retryConfig);
-        $this->handlerStack->push($retryMiddlewareFactory->create());
+        $this->handlerStack->push($retryMiddlewareFactory->create(), 'retry');
 
         // Create Guzzle client
         $guzzle = new Client($guzzleConfig);


### PR DESCRIPTION
Changes:
- Added name for retry middleware, so SSH tunnel middleware can be linked.