### PR TITLE
Allow numeric (but string) endpoint

### DIFF
--- a/src/Client/RestRequest.php
+++ b/src/Client/RestRequest.php
@@ -29,7 +29,7 @@ class RestRequest
      */
     public function __construct(array $config)
     {
-        if (empty($config['endpoint']) || !is_string($config['endpoint'])) {
+        if (!isset($config['endpoint']) || !is_string($config['endpoint'])) {
             throw new UserException('The "endpoint" property must be specified in request as a string.');
         }
         $this->endpoint = $config['endpoint'];

--- a/tests/phpunit/Client/RestRequestTest.php
+++ b/tests/phpunit/Client/RestRequestTest.php
@@ -42,6 +42,18 @@ class RestRequestTest extends TestCase
         self::assertEquals('GET ep first=foo&second=bar', (string) $request);
     }
 
+    public function testNumericEndpoint(): void
+    {
+        $request = new RestRequest([
+            'endpoint' => '0',
+        ]);
+
+        self::assertEquals([], $request->getHeaders());
+        self::assertEquals('0', $request->getEndpoint());
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals([], $request->getParams());
+    }
+
     public function testToStringPost(): void
     {
         $request = new RestRequest([


### PR DESCRIPTION
Follow-up to #45 

Changes:
- Failing test
- Change how endpoint is checked